### PR TITLE
vim-style search on todos tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ Download the Windows release binary from the latest GitHub Release:
 - `orivo-vX.Y.Z-windows-aarch64.exe`
 
 ```powershell
-PS> mv orivo-vX.Y.Z-windows-x86_64.exe orivo.exe
+> mv orivo-vX.Y.Z-windows-x86_64.exe orivo.exe
 ```
 
 Then place the binary somewhere on your `PATH`.
 
 Run from any terminal:
 ```powershell
-PS> orivo
+> orivo
 ```
 
 ### Cargo (any OS, builds from source)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A terminal-based (TUI) Todos + Pomodoro timer written in [Rust](https://www.rust
 
 ## Installation
 
-### Linux Or macOS
+### Linux or macOS
 
 ```sh
 curl -fsSL https://github.com/mt-shihab26/orivo/releases/latest/download/install.sh | bash
@@ -23,30 +23,40 @@ curl -fsSL https://github.com/mt-shihab26/orivo/releases/latest/download/install
 The script will:
 
 - **Install sqlite3** — the only system dependency, detected and installed automatically for your distro
-- **Install the binary** — fetches the latest release for your OS and architecture. places `orivo` in `~/.local/bin`
-- **Install the desktop entry** *(Linux only)* — registers orivo in your launcher. Defaults to kitty; pass `-s -- --terminal alacritty` to use alacritty instead
+- **Install the binary** — fetches the latest release for your OS and architecture, then places `orivo` in `~/.local/bin`
+- **Install the desktop entry** *(Linux only)* — registers orivo in your launcher (defaults to Kitty; pass `-s -- --terminal alacritty` to use Alacritty instead)
 - **Install the icon** *(Linux only)* — installs the app icon to the hicolor theme for the desktop entry
 
 > Running the same command again will **upgrade** to the latest version, or do nothing if already up to date.
 
+Usage:
+
+1. Search for orivo in your launcher (opens in Kitty or Alacritty)
+2. Run from any terminal (`~/.local/bin` must be in your `PATH`):
+```sh
+orivo
+```
+
 ### Windows
 
-> **Requires sqlite3** — install it and ensure it's on your `PATH` before running.
+**Requires sqlite3** — install it and ensure it's on your `PATH` before running.
 
 Download the Windows release binary from the latest GitHub Release:
 
 - `orivo-vX.Y.Z-windows-x86_64.exe`
 - `orivo-vX.Y.Z-windows-aarch64.exe`
 
-
 ```powershell
 mv orivo-vX.Y.Z-windows-x86_64.exe orivo.exe
 ```
 
-Then place it somewhere on your `PATH`, or keep it in a directory of your choice and run it directly:
+Then place the binary somewhere on your `PATH`.
 
+Usage:
+
+Run from any terminal:
 ```powershell
-.\orivo.exe
+orivo
 ```
 
 ### Cargo (any OS, builds from source)
@@ -55,6 +65,13 @@ Then place it somewhere on your `PATH`, or keep it in a directory of your choice
 
 ```sh
 cargo install orivo
+```
+
+Usage:
+
+Run from any terminal:
+```sh
+orivo
 ```
 
 ## Configuration
@@ -96,7 +113,7 @@ daily_session_goal  = 16      # target work sessions to complete today (min: 1, 
 
 ### Database (`[db]`)
 
-Orivo uses [Turso](https://turso.tech) as its database — a libSQL-compatible SQLite database built on top of SQLite. You need a `url` and `token` to connect.
+Orivo uses [Turso](https://turso.tech) as its database — a libSQL-compatible SQLite database. You need a `url` and `token` to connect.
 
 ```sh
 turso auth login
@@ -119,7 +136,7 @@ A full cycle = `work_duration` × `long_break_interval` work sessions. After tha
 work → break → work → break → work → break → work → LONG BREAK  (cycle of 4)
 ```
 
-**Daily session goal** (`daily_session_goal`) sets how many work sessions you aim to complete each day. Progress is shown as a session tracker in the timer tab. Once the goal is reached the tracker fills completely.
+**Daily session goal** (`daily_session_goal`) sets how many work sessions you aim to complete each day. Progress is shown as a session tracker in the timer tab. Once the goal is reached, the tracker fills completely.
 
 - Default: `16` sessions
 - Range: `1` – `24` sessions

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A terminal-based (TUI) Todos + Pomodoro timer written in [Rust](https://www.rust
 
 ## Installation
 
-### Linux and macOS
+### Linux Or macOS
 
 ```sh
 curl -fsSL https://github.com/mt-shihab26/orivo/releases/latest/download/install.sh | bash
@@ -30,6 +30,8 @@ The script will:
 > Running the same command again will **upgrade** to the latest version, or do nothing if already up to date.
 
 ### Windows
+
+> **Requires sqlite3** — install it and ensure it's on your `PATH` before running.
 
 Download the Windows release binary from the latest GitHub Release:
 
@@ -48,6 +50,8 @@ Then place it somewhere on your `PATH`, or keep it in a directory of your choice
 ```
 
 ### Cargo (any OS, builds from source)
+
+> **Requires sqlite3** — install it for your OS and ensure it's on your `PATH` before building.
 
 ```sh
 cargo install orivo

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ mv orivo-vX.Y.Z-windows-x86_64.exe orivo.exe
 
 Then place the binary somewhere on your `PATH`.
 
-Usage:
-
 Run from any terminal:
 ```powershell
 orivo
@@ -61,13 +59,11 @@ orivo
 
 ### Cargo (any OS, builds from source)
 
-> **Requires sqlite3** — install it for your OS and ensure it's on your `PATH` before building.
+**Requires sqlite3** — install it for your OS and ensure it's on your `PATH` before building.
 
 ```sh
 cargo install orivo
 ```
-
-Usage:
 
 Run from any terminal:
 ```sh

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Usage:
 1. Search for orivo in your launcher (opens in Kitty or Alacritty)
 2. Run from any terminal (`~/.local/bin` must be in your `PATH`):
 ```sh
-orivo
+$ orivo
 ```
 
 ### Windows
@@ -47,14 +47,14 @@ Download the Windows release binary from the latest GitHub Release:
 - `orivo-vX.Y.Z-windows-aarch64.exe`
 
 ```powershell
-mv orivo-vX.Y.Z-windows-x86_64.exe orivo.exe
+PS> mv orivo-vX.Y.Z-windows-x86_64.exe orivo.exe
 ```
 
 Then place the binary somewhere on your `PATH`.
 
 Run from any terminal:
 ```powershell
-orivo
+PS> orivo
 ```
 
 ### Cargo (any OS, builds from source)
@@ -62,12 +62,12 @@ orivo
 **Requires sqlite3** — install it for your OS and ensure it's on your `PATH` before building.
 
 ```sh
-cargo install orivo
+$ cargo install orivo
 ```
 
 Run from any terminal:
 ```sh
-orivo
+$ orivo
 ```
 
 ## Configuration
@@ -112,10 +112,10 @@ daily_session_goal  = 16      # target work sessions to complete today (min: 1, 
 Orivo uses [Turso](https://turso.tech) as its database — a libSQL-compatible SQLite database. You need a `url` and `token` to connect.
 
 ```sh
-turso auth login
-turso db create orivo
-turso db show orivo --url      # → paste as url
-turso db tokens create orivo   # → paste as token
+$ turso auth login
+$ turso db create orivo
+$ turso db show orivo --url      # → paste as url
+$ turso db tokens create orivo   # → paste as token
 ```
 
 ### Timer (`[timer]`)

--- a/README.md
+++ b/README.md
@@ -23,20 +23,11 @@ curl -fsSL https://github.com/mt-shihab26/orivo/releases/latest/download/install
 The script will:
 
 - **Install sqlite3** — the only system dependency, detected and installed automatically for your distro
-- **Download the binary** — fetches the latest release for your OS and architecture
-- **Install the binary** — places `orivo` in `~/.local/bin`
-- **Install the desktop entry** *(Linux only)* — registers orivo as an app so it appears in your launcher
-- **Support desktop terminal selection** *(Linux only)* — use `--terminal kitty` or `--terminal alacritty` for the desktop entry
-- **Install the icon** *(Linux only)* — installs the app icon to the hicolor theme
+- **Install the binary** — fetches the latest release for your OS and architecture. places `orivo` in `~/.local/bin`
+- **Install the desktop entry** *(Linux only)* — registers orivo in your launcher. Defaults to kitty; pass `-s -- --terminal alacritty` to use alacritty instead
+- **Install the icon** *(Linux only)* — installs the app icon to the hicolor theme for the desktop entry
 
-Running the same command again will **upgrade** to the latest version, or do nothing if already up to date.
-
-Options:
-
-```sh
-# Choose terminal for the desktop entry (default: kitty)
-curl -fsSL https://github.com/mt-shihab26/orivo/releases/latest/download/install.sh | bash -s -- --terminal alacritty
-```
+> Running the same command again will **upgrade** to the latest version, or do nothing if already up to date.
 
 ### Windows
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # Todos
 
 1. [x] Add notification when a session is done
-2. Implement search features on each page
+2. Implement search features on each page. by / it will open the search bar for searching todos on each pages of todos tab
 3. [!] Add sound to the notification
 4. [x] Progress is shown as a session tracker in the timer tab. Once the goal is reached the tracker fills completely. Add Progress tracker.
 5. [x] Store the remaining time on persist state every minute and when pause and quit etc.

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -1,6 +1,7 @@
 /// Help command that prints usage for all available commands.
 pub mod help;
-/// Development command that resets and seeds the database.
+/// Development command that resets and seeds the database (excluded from release builds).
+#[cfg(debug_assertions)]
 pub mod seed;
 /// Command that launches the terminal UI.
 pub mod tui;

--- a/src/kinds/todos_mode.rs
+++ b/src/kinds/todos_mode.rs
@@ -7,4 +7,6 @@ pub enum TodosMode {
     Adding,
     /// Input mode for editing the selected todo.
     Editing,
+    /// Search mode for filtering todos by text on the current page.
+    Searching,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use std::{
 };
 
 use orivo::{
-    cmds::{Cmd, help::Help, seed::Seed, tui::Tui, version::Version},
+    cmds::{Cmd, help::Help, tui::Tui, version::Version},
     config::Config,
     utils::db,
 };
@@ -30,7 +30,8 @@ use orivo::{
 fn main() -> Result<()> {
     match env::args().nth(1).as_deref() {
         None | Some("tui") => Box::new(Tui::new(Config::load()?, db::connect()?)).run(),
-        Some("seed") => Box::new(Seed::new()).run(),
+        #[cfg(debug_assertions)]
+        Some("seed") => Box::new(orivo::cmds::seed::Seed::new()).run(),
         Some("version") | Some("--version") | Some("-V") => Box::new(Version::new()).run(),
         Some("help") | Some("--help") | Some("-h") => help(),
         Some(cmd) => unknown(cmd),
@@ -39,7 +40,10 @@ fn main() -> Result<()> {
 
 /// Builds and runs the aggregated help command.
 fn help() -> Result<()> {
-    let helps = [Tui::help, Seed::help, Version::help, Help::help];
+    #[cfg(debug_assertions)]
+    let helps = [Tui::help, orivo::cmds::seed::Seed::help, Version::help, Help::help];
+    #[cfg(not(debug_assertions))]
+    let helps = [Tui::help, Version::help, Help::help];
     Box::new(Help::new(&helps)).run()
 }
 

--- a/src/models/todo.rs
+++ b/src/models/todo.rs
@@ -117,6 +117,39 @@ impl Todo {
         }
     }
 
+    /// Returns a paginated list of todos matching `query` (case-insensitive) on the given page.
+    pub fn list_search(db: &DatabaseConnection, page: Page, query: &str, offset: usize, limit: usize) -> Vec<Todo> {
+        if limit == 0 {
+            return vec![];
+        }
+        let pattern = format!("%{}%", query.to_lowercase());
+        let query_stmt = Self::base_query(page)
+            .filter(Expr::cust_with_values("lower(text) LIKE ?", [pattern]))
+            .offset(offset as u64)
+            .limit(limit as u64);
+        match rt().block_on(async { query_stmt.all(db).await.map_err(io_err) }) {
+            Ok(models) => models.into_iter().map(Todo::from).collect(),
+            Err(e) => {
+                log_error!("failed to search todos: {e}");
+                vec![]
+            }
+        }
+    }
+
+    /// Returns the total number of todos matching `query` (case-insensitive) on the given page.
+    pub fn count_search(db: &DatabaseConnection, page: Page, query: &str) -> usize {
+        let pattern = format!("%{}%", query.to_lowercase());
+        let query_stmt = Self::base_query(page)
+            .filter(Expr::cust_with_values("lower(text) LIKE ?", [pattern]));
+        match rt().block_on(async { query_stmt.count(db).await.map_err(io_err) }) {
+            Ok(count) => count as usize,
+            Err(e) => {
+                log_error!("failed to count search results: {e}");
+                0
+            }
+        }
+    }
+
     /// Returns a paginated list of todos for the given page filter.
     pub fn list(db: &DatabaseConnection, page: Page, offset: usize, limit: usize) -> Vec<Todo> {
         if limit == 0 {

--- a/src/models/todo.rs
+++ b/src/models/todo.rs
@@ -127,7 +127,9 @@ impl Todo {
         if limit == 0 {
             return vec![];
         }
-        let query_stmt = Self::base_search_query(page, query).offset(offset as u64).limit(limit as u64);
+        let query_stmt = Self::base_search_query(page, query)
+            .offset(offset as u64)
+            .limit(limit as u64);
         match rt().block_on(async { query_stmt.all(db).await.map_err(io_err) }) {
             Ok(models) => models.into_iter().map(Todo::from).collect(),
             Err(e) => {

--- a/src/models/todo.rs
+++ b/src/models/todo.rs
@@ -117,16 +117,17 @@ impl Todo {
         }
     }
 
+    fn base_search_query(page: Page, query: &str) -> sea_orm::Select<Entity> {
+        let pattern = format!("%{}%", query.to_lowercase());
+        Self::base_query(page).filter(Expr::cust_with_values("lower(text) LIKE ?", [pattern]))
+    }
+
     /// Returns a paginated list of todos matching `query` (case-insensitive) on the given page.
     pub fn list_search(db: &DatabaseConnection, page: Page, query: &str, offset: usize, limit: usize) -> Vec<Todo> {
         if limit == 0 {
             return vec![];
         }
-        let pattern = format!("%{}%", query.to_lowercase());
-        let query_stmt = Self::base_query(page)
-            .filter(Expr::cust_with_values("lower(text) LIKE ?", [pattern]))
-            .offset(offset as u64)
-            .limit(limit as u64);
+        let query_stmt = Self::base_search_query(page, query).offset(offset as u64).limit(limit as u64);
         match rt().block_on(async { query_stmt.all(db).await.map_err(io_err) }) {
             Ok(models) => models.into_iter().map(Todo::from).collect(),
             Err(e) => {
@@ -138,9 +139,7 @@ impl Todo {
 
     /// Returns the total number of todos matching `query` (case-insensitive) on the given page.
     pub fn count_search(db: &DatabaseConnection, page: Page, query: &str) -> usize {
-        let pattern = format!("%{}%", query.to_lowercase());
-        let query_stmt = Self::base_query(page)
-            .filter(Expr::cust_with_values("lower(text) LIKE ?", [pattern]));
+        let query_stmt = Self::base_search_query(page, query);
         match rt().block_on(async { query_stmt.count(db).await.map_err(io_err) }) {
             Ok(count) => count as usize,
             Err(e) => {

--- a/src/states/todos.rs
+++ b/src/states/todos.rs
@@ -119,9 +119,11 @@ impl TodosState {
 
     /// Sets the search query and resets pagination; re-fetches results on the next access.
     pub fn set_search_query(&mut self, query: String, page: Page) {
+        if self.search_query == query {
+            return;
+        }
         self.search_query = query;
-        *self.search_items.borrow_mut() = None;
-        *self.search_count.borrow_mut() = None;
+        self.invalidate_search_caches();
         self.offset = 0;
         self.selected = 0;
         self.clamp_selected(page);
@@ -130,6 +132,10 @@ impl TodosState {
     /// Clears the search query and invalidates search caches.
     pub fn clear_search(&mut self) {
         self.search_query.clear();
+        self.invalidate_search_caches();
+    }
+
+    fn invalidate_search_caches(&self) {
         *self.search_items.borrow_mut() = None;
         *self.search_count.borrow_mut() = None;
     }
@@ -212,8 +218,7 @@ impl TodosState {
     /// Invalidates all todo caches including search results.
     fn clear_caches(&self) {
         self.todos_cache.invalidate_all();
-        *self.search_items.borrow_mut() = None;
-        *self.search_count.borrow_mut() = None;
+        self.invalidate_search_caches();
     }
 
     /// Invalidates the timer cache's todo list so the picker reflects recent changes.

--- a/src/states/todos.rs
+++ b/src/states/todos.rs
@@ -34,6 +34,12 @@ pub struct TodosState {
     todos_cache: TodosCache,
     /// Shared timer cache, invalidated when todos change.
     timer_cache: Arc<Mutex<TimerCache>>,
+    /// Active search query; empty string means no search is active.
+    search_query: String,
+    /// Cached search result page; invalidated when query or offset changes.
+    search_items: RefCell<Option<Vec<Todo>>>,
+    /// Cached total count of search results; invalidated when query or data changes.
+    search_count: RefCell<Option<usize>>,
 }
 
 impl TodosState {
@@ -48,6 +54,9 @@ impl TodosState {
             page_size: Cell::new(1),
             list_state: RefCell::new(ListState::default()),
             timer_cache,
+            search_query: String::new(),
+            search_items: RefCell::new(None),
+            search_count: RefCell::new(None),
         }
     }
 
@@ -98,10 +107,50 @@ impl TodosState {
         self.offset + loaded_len < total
     }
 
+    /// Returns the active search query (empty string means no search is active).
+    pub fn search_query(&self) -> &str {
+        &self.search_query
+    }
+
+    /// Returns `true` when a non-empty search filter is applied.
+    pub fn is_searching(&self) -> bool {
+        !self.search_query.is_empty()
+    }
+
+    /// Sets the search query and resets pagination; re-fetches results on the next access.
+    pub fn set_search_query(&mut self, query: String, page: Page) {
+        self.search_query = query;
+        *self.search_items.borrow_mut() = None;
+        *self.search_count.borrow_mut() = None;
+        self.offset = 0;
+        self.selected = 0;
+        self.clamp_selected(page);
+    }
+
+    /// Clears the search query and invalidates search caches.
+    pub fn clear_search(&mut self) {
+        self.search_query.clear();
+        *self.search_items.borrow_mut() = None;
+        *self.search_count.borrow_mut() = None;
+    }
+
+    /// Returns a cached page of search results, querying the DB if the cache is empty.
+    fn get_search_items(&self, page: Page) -> Ref<'_, [Todo]> {
+        if self.search_items.borrow().is_none() {
+            *self.search_items.borrow_mut() = Some(Todo::list_search(
+                &self.db,
+                page,
+                &self.search_query,
+                self.offset,
+                self.page_size(),
+            ));
+        }
+        Ref::map(self.search_items.borrow(), |c| c.as_deref().unwrap_or(&[]))
+    }
+
     /// Returns session stats for each visible todo on the given page.
     pub fn stats(&self, page: Page) -> Vec<Option<Stat>> {
-        self.todos_cache
-            .get_items(page, self.offset, self.page_size())
+        self.items(page)
             .iter()
             .map(|t| t.id.map(|id| Session::stat(&self.db, id)))
             .collect()
@@ -109,18 +158,38 @@ impl TodosState {
 
     /// Returns a borrowed slice of the visible todos for the given page.
     pub fn items(&self, page: Page) -> Ref<'_, [Todo]> {
-        self.todos_cache.get_items(page, self.offset, self.page_size())
+        if self.search_query.is_empty() {
+            self.todos_cache.get_items(page, self.offset, self.page_size())
+        } else {
+            self.get_search_items(page)
+        }
     }
 
     /// Returns the total number of todos for the given page.
     pub fn count(&self, page: Page) -> usize {
-        self.todos_cache.get_count(page)
+        if self.search_query.is_empty() {
+            self.todos_cache.get_count(page)
+        } else {
+            let mut count = self.search_count.borrow_mut();
+            if count.is_none() {
+                *count = Some(Todo::count_search(&self.db, page, &self.search_query));
+            }
+            count.unwrap_or(0)
+        }
     }
 
     /// Returns a borrowed reference to the currently selected todo, if any.
     pub fn selected_item(&self, page: Page) -> Option<Ref<'_, Todo>> {
-        self.todos_cache
-            .get_item_at(page, self.offset, self.page_size(), self.selected)
+        if self.search_query.is_empty() {
+            self.todos_cache
+                .get_item_at(page, self.offset, self.page_size(), self.selected)
+        } else {
+            let items = self.get_search_items(page);
+            if items.get(self.selected).is_none() {
+                return None;
+            }
+            Some(Ref::map(items, |items| &items[self.selected]))
+        }
     }
 
     /// Updates the visible capacity based on the rendered list area and invalidates caches on change.
@@ -140,9 +209,11 @@ impl TodosState {
         self.page_size.get().max(1)
     }
 
-    /// Invalidates all todo caches.
+    /// Invalidates all todo caches including search results.
     fn clear_caches(&self) {
         self.todos_cache.invalidate_all();
+        *self.search_items.borrow_mut() = None;
+        *self.search_count.borrow_mut() = None;
     }
 
     /// Invalidates the timer cache's todo list so the picker reflects recent changes.
@@ -152,9 +223,10 @@ impl TodosState {
         }
     }
 
-    /// Invalidates only the items cache, keeping counts intact.
+    /// Invalidates only the items cache (keeping counts), including the search items page.
     fn invalidate_items(&self) {
         self.todos_cache.invalidate_items();
+        *self.search_items.borrow_mut() = None;
     }
 
     /// Returns `true` if the selected todo on the given page can be deleted.

--- a/src/tabs/todos.rs
+++ b/src/tabs/todos.rs
@@ -22,6 +22,7 @@ use crate::{
         hint::{HintProps, HintWidget},
         input::{InputAction, InputProps, InputState, InputWidget},
         list::{ListProps, ListWidget},
+        search::{SearchAction, SearchState, SearchWidget},
         status::{StatusProps, StatusWidget},
         tabs::{TabsProps, TabsWidget},
     },
@@ -42,6 +43,8 @@ pub struct TodosTab {
     state: TodosState,
     /// Active text input state when adding or editing a todo.
     input_state: Option<InputState>,
+    /// Active search bar state when in Searching mode.
+    search_state: Option<SearchState>,
 }
 
 impl TodosTab {
@@ -52,6 +55,7 @@ impl TodosTab {
             mode: TodosMode::Normal,
             state: TodosState::new(db, timer_cache),
             input_state: None,
+            search_state: None,
         }
     }
 
@@ -76,6 +80,25 @@ impl TodosTab {
         self.input_state = None;
         self.mode = TodosMode::Normal;
     }
+
+    /// Opens the search bar pre-filled with any active query.
+    fn open_search(&mut self) {
+        self.search_state = Some(SearchState::new(self.state.search_query()));
+        self.mode = TodosMode::Searching;
+    }
+
+    /// Closes the search bar, keeping the current filter active.
+    fn confirm_search(&mut self) {
+        self.search_state = None;
+        self.mode = TodosMode::Normal;
+    }
+
+    /// Closes the search bar and clears the filter entirely.
+    fn cancel_search(&mut self) {
+        self.state.clear_search();
+        self.search_state = None;
+        self.mode = TodosMode::Normal;
+    }
 }
 
 impl Tab for TodosTab {
@@ -89,7 +112,7 @@ impl Tab for TodosTab {
         COLOR
     }
 
-    /// Handles a key event, delegating to input or normal-mode handlers.
+    /// Handles a key event, delegating to input, search, or normal-mode handlers.
     fn handle(&mut self, key: KeyEvent) -> Result<()> {
         let pending_g = self.state.begin_input();
 
@@ -121,6 +144,12 @@ impl Tab for TodosTab {
                             Some(InputState::new(InputProps::new(Some(&text), due_date, repeat.as_ref())));
                     }
                 }
+                KeyCode::Char('/') => self.open_search(),
+                KeyCode::Esc => {
+                    if self.state.is_searching() {
+                        self.state.clear_search();
+                    }
+                }
                 _ => {}
             },
             TodosMode::Adding => {
@@ -147,12 +176,24 @@ impl Tab for TodosTab {
                     }
                 }
             }
+            TodosMode::Searching => {
+                if let Some(search) = &mut self.search_state {
+                    match search.handle(key) {
+                        SearchAction::Confirm => self.confirm_search(),
+                        SearchAction::Cancel => self.cancel_search(),
+                        SearchAction::QueryChanged(query) => {
+                            self.state.set_search_query(query, self.page);
+                        }
+                        SearchAction::None => {}
+                    }
+                }
+            }
         }
         self.state.sync_list_state(self.items().len());
         Ok(())
     }
 
-    /// Renders the todos tab including the list, tabs bar, hint, and input overlay.
+    /// Renders the todos tab including the list, tabs bar, hint, and input/search overlay.
     fn render(&self, frame: &mut Frame, area: Rect) {
         let buf = frame.buffer_mut();
 
@@ -162,21 +203,21 @@ impl Tab for TodosTab {
 
         let area = inner;
 
-        let (tabs_area, list_area, hint_area, input_area) = match self.mode {
+        let (tabs_area, list_area, hint_area, bottom_area) = match self.mode {
             TodosMode::Normal => {
                 let [tabs, list, hint] =
                     Layout::vertical([Constraint::Length(1), Constraint::Fill(1), Constraint::Length(1)]).areas(area);
                 (tabs, list, hint, None)
             }
-            TodosMode::Adding | TodosMode::Editing => {
-                let [tabs, list, hint, input] = Layout::vertical([
+            TodosMode::Adding | TodosMode::Editing | TodosMode::Searching => {
+                let [tabs, list, hint, bottom] = Layout::vertical([
                     Constraint::Length(1),
                     Constraint::Fill(1),
                     Constraint::Length(1),
                     Constraint::Length(3),
                 ])
                 .areas(area);
-                (tabs, list, hint, Some(input))
+                (tabs, list, hint, Some(bottom))
             }
         };
 
@@ -189,9 +230,7 @@ impl Tab for TodosTab {
         let page = self.state.page();
 
         frame.render_widget(&StatusWidget::new(&StatusProps::new(total, from, to, page)), area);
-
         frame.render_widget(&TabsWidget::new(&TabsProps::new(self.page, self.color())), tabs_area);
-
         frame.render_widget(
             &ListWidget::new(&ListProps::new(
                 &items,
@@ -206,14 +245,28 @@ impl Tab for TodosTab {
             list_area,
         );
 
-        HintWidget::new(&HintProps::new(self.mode, self.state.can_delete(self.page, &items)))
-            .render(hint_area, frame.buffer_mut());
+        HintWidget::new(&HintProps::new(
+            self.mode,
+            self.state.can_delete(self.page, &items),
+            self.state.search_query().to_owned(),
+        ))
+        .render(hint_area, frame.buffer_mut());
 
-        if let Some(input_rect) = input_area {
-            if let Some(input_state) = &self.input_state {
-                let props = input_state.props();
-                frame.render_widget(&InputWidget::new(&props), input_rect);
-                input_state.render_calendar(frame, area);
+        if let Some(bottom_rect) = bottom_area {
+            match self.mode {
+                TodosMode::Adding | TodosMode::Editing => {
+                    if let Some(input_state) = &self.input_state {
+                        let props = input_state.props();
+                        frame.render_widget(&InputWidget::new(props), bottom_rect);
+                        input_state.render_calendar(frame, area);
+                    }
+                }
+                TodosMode::Searching => {
+                    if let Some(search_state) = &self.search_state {
+                        SearchWidget::new(search_state).render(bottom_rect, frame.buffer_mut());
+                    }
+                }
+                TodosMode::Normal => {}
             }
         }
     }

--- a/src/tabs/todos.rs
+++ b/src/tabs/todos.rs
@@ -22,7 +22,7 @@ use crate::{
         hint::{HintProps, HintWidget},
         input::{InputAction, InputProps, InputState, InputWidget},
         list::{ListProps, ListWidget},
-        search::{SearchAction, SearchState, SearchWidget},
+        search::{SearchAction, SearchProps, SearchState, SearchWidget},
         status::{StatusProps, StatusWidget},
         tabs::{TabsProps, TabsWidget},
     },
@@ -203,13 +203,8 @@ impl Tab for TodosTab {
 
         let area = inner;
 
-        let (tabs_area, list_area, hint_area, bottom_area) = match self.mode {
-            TodosMode::Normal => {
-                let [tabs, list, hint] =
-                    Layout::vertical([Constraint::Length(1), Constraint::Fill(1), Constraint::Length(1)]).areas(area);
-                (tabs, list, hint, None)
-            }
-            TodosMode::Adding | TodosMode::Editing | TodosMode::Searching => {
+        let (tabs_area, list_area, hint_area, bottom_area) =
+            if matches!(self.mode, TodosMode::Adding | TodosMode::Editing) {
                 let [tabs, list, hint, bottom] = Layout::vertical([
                     Constraint::Length(1),
                     Constraint::Fill(1),
@@ -218,8 +213,24 @@ impl Tab for TodosTab {
                 ])
                 .areas(area);
                 (tabs, list, hint, Some(bottom))
-            }
-        };
+            } else if matches!(self.mode, TodosMode::Searching) || self.state.is_searching() {
+                let [tabs, list, hint, bottom] = Layout::vertical([
+                    Constraint::Length(1),
+                    Constraint::Fill(1),
+                    Constraint::Length(1),
+                    Constraint::Length(1),
+                ])
+                .areas(area);
+                (tabs, list, hint, Some(bottom))
+            } else {
+                let [tabs, list, hint] = Layout::vertical([
+                    Constraint::Length(1),
+                    Constraint::Fill(1),
+                    Constraint::Length(1),
+                ])
+                .areas(area);
+                (tabs, list, hint, None)
+            };
 
         self.state.set_visible_capacity(list_area);
         let items = self.items();
@@ -229,44 +240,39 @@ impl Tab for TodosTab {
         let to = self.state.to(items.len());
         let page = self.state.page();
 
-        frame.render_widget(&StatusWidget::new(&StatusProps::new(total, from, to, page)), area);
-        frame.render_widget(&TabsWidget::new(&TabsProps::new(self.page, self.color())), tabs_area);
-        frame.render_widget(
-            &ListWidget::new(&ListProps::new(
-                &items,
-                &stats,
-                self.state.offset(),
-                self.page,
-                self.state.selected(),
-                self.color(),
-                self.state.show_more_above(),
-                self.state.show_more_below(items.len(), total),
-            )),
-            list_area,
-        );
-
-        HintWidget::new(&HintProps::new(
-            self.mode,
-            self.state.can_delete(self.page, &items),
-            self.state.search_query().to_owned(),
+        StatusWidget::new(&StatusProps::new(total, from, to, page)).render(area, buf);
+        TabsWidget::new(&TabsProps::new(self.page, self.color())).render(tabs_area, buf);
+        ListWidget::new(&ListProps::new(
+            &items,
+            &stats,
+            self.state.offset(),
+            self.page,
+            self.state.selected(),
+            self.color(),
+            self.state.show_more_above(),
+            self.state.show_more_below(items.len(), total),
         ))
-        .render(hint_area, frame.buffer_mut());
+        .render(list_area, buf);
+        HintWidget::new(&HintProps::new(self.mode, self.state.can_delete(self.page, &items), self.state.is_searching()))
+            .render(hint_area, buf);
 
         if let Some(bottom_rect) = bottom_area {
             match self.mode {
                 TodosMode::Adding | TodosMode::Editing => {
                     if let Some(input_state) = &self.input_state {
-                        let props = input_state.props();
-                        frame.render_widget(&InputWidget::new(props), bottom_rect);
-                        input_state.render_calendar(frame, area);
+                        InputWidget::new(input_state.props()).render(bottom_rect, buf);
+                        input_state.render_calendar(area, buf);
                     }
                 }
                 TodosMode::Searching => {
                     if let Some(search_state) = &self.search_state {
-                        SearchWidget::new(search_state).render(bottom_rect, frame.buffer_mut());
+                        SearchWidget::new(search_state.props()).render(bottom_rect, buf);
                     }
                 }
-                TodosMode::Normal => {}
+                TodosMode::Normal => {
+                    let props = SearchProps::new(self.state.search_query(), false);
+                    SearchWidget::new(&props).render(bottom_rect, buf);
+                }
             }
         }
     }

--- a/src/tabs/todos.rs
+++ b/src/tabs/todos.rs
@@ -221,12 +221,8 @@ impl Tab for TodosTab {
                 .areas(area);
                 (tabs, list, hint, Some(bottom))
             } else {
-                let [tabs, list, hint] = Layout::vertical([
-                    Constraint::Length(1),
-                    Constraint::Fill(1),
-                    Constraint::Length(1),
-                ])
-                .areas(area);
+                let [tabs, list, hint] =
+                    Layout::vertical([Constraint::Length(1), Constraint::Fill(1), Constraint::Length(1)]).areas(area);
                 (tabs, list, hint, None)
             };
 
@@ -251,8 +247,12 @@ impl Tab for TodosTab {
             self.state.show_more_below(items.len(), total),
         ))
         .render(list_area, buf);
-        HintWidget::new(&HintProps::new(self.mode, self.state.can_delete(self.page, &items), self.state.is_searching()))
-            .render(hint_area, buf);
+        HintWidget::new(&HintProps::new(
+            self.mode,
+            self.state.can_delete(self.page, &items),
+            self.state.is_searching(),
+        ))
+        .render(hint_area, buf);
 
         if let Some(bottom_rect) = bottom_area {
             match self.mode {

--- a/src/tabs/todos.rs
+++ b/src/tabs/todos.rs
@@ -7,8 +7,7 @@ use std::{
 use ratatui::{
     Frame,
     crossterm::event::{KeyCode, KeyEvent, KeyModifiers},
-    prelude::{Color, Constraint, Layout, Rect, Stylize, Widget},
-    widgets::Block,
+    prelude::{Color, Constraint, Layout, Rect, Widget},
 };
 use sea_orm::DatabaseConnection;
 
@@ -18,13 +17,16 @@ use crate::{
     models::todo::Todo,
     states::todos::TodosState,
     utils::date::now,
-    widgets::todos::{
-        hint::{HintProps, HintWidget},
-        input::{InputAction, InputProps, InputState, InputWidget},
-        list::{ListProps, ListWidget},
-        search::{SearchAction, SearchProps, SearchState, SearchWidget},
-        status::{StatusProps, StatusWidget},
-        tabs::{TabsProps, TabsWidget},
+    widgets::{
+        layout::border::{BorderProps, BorderWidget},
+        todos::{
+            hint::{HintProps, HintWidget},
+            input::{InputAction, InputProps, InputState, InputWidget},
+            list::{ListProps, ListWidget},
+            search::{SearchAction, SearchProps, SearchState, SearchWidget},
+            status::{StatusProps, StatusWidget},
+            tabs::{TabsProps, TabsWidget},
+        },
     },
 };
 
@@ -197,11 +199,7 @@ impl Tab for TodosTab {
     fn render(&self, frame: &mut Frame, area: Rect) {
         let buf = frame.buffer_mut();
 
-        let block = Block::bordered().fg(self.color());
-        let inner = block.inner(area);
-        block.render(area, buf);
-
-        let area = inner;
+        let area = BorderWidget::new(&BorderProps::new(self.color()), area).render(area, buf);
 
         let (tabs_area, list_area, hint_area, bottom_area) =
             if matches!(self.mode, TodosMode::Adding | TodosMode::Editing) {

--- a/src/widgets/todos/hint.rs
+++ b/src/widgets/todos/hint.rs
@@ -11,20 +11,19 @@ pub struct HintProps {
     ui_mode: TodosMode,
     /// Whether the delete action is available for the selected todo.
     can_delete: bool,
-    /// Active search query shown inline; empty string means no search is active.
-    search_query: String,
+    /// Whether a search filter is currently active.
+    is_searching: bool,
 }
 
 impl HintProps {
-    /// Creates new hint props from the current mode, delete availability, and active search query.
-    pub fn new(ui_mode: TodosMode, can_delete: bool, search_query: String) -> Self {
-        Self { ui_mode, can_delete, search_query }
+    /// Creates new hint props from the current mode, delete availability, and search state.
+    pub fn new(ui_mode: TodosMode, can_delete: bool, is_searching: bool) -> Self {
+        Self { ui_mode, can_delete, is_searching }
     }
 }
 
 /// Stateless widget that renders context-sensitive key hints for the todos tab.
 pub struct HintWidget<'a> {
-    /// Borrowed hint props for this render pass.
     props: &'a HintProps,
 }
 
@@ -36,27 +35,16 @@ impl<'a> HintWidget<'a> {
 }
 
 impl Widget for &HintWidget<'_> {
-    /// Renders the appropriate hint text centered in the buffer.
     fn render(self, area: Rect, buf: &mut Buffer) {
         let hint = match self.props.ui_mode {
-            TodosMode::Normal => {
-                let base = if self.props.can_delete {
-                    "[[/]]Page  [j/k]Navigate  [Space]Toggle  [a]Add  [e]Edit  [^r]Delete  [/]Search"
-                } else {
-                    "[[/]]Page  [j/k]Navigate  [Space]Toggle  [a]Add  [e]Edit  [/]Search"
-                };
-                if !self.props.search_query.is_empty() {
-                    format!("{}  \"{}\"", base, self.props.search_query)
-                } else {
-                    base.to_string()
-                }
-            }
-            TodosMode::Adding | TodosMode::Editing => {
-                "[Enter]Confirm  [Esc]Cancel  [Backspace]Delete char".to_string()
-            }
-            TodosMode::Searching => {
-                "[Enter]Confirm search  [Esc]Cancel search  [Backspace]Delete char".to_string()
-            }
+            TodosMode::Normal => match (self.props.can_delete, self.props.is_searching) {
+                (true, false) => "[[/]]Page  [j/k]Navigate  [Space]Toggle  [a]Add  [e]Edit  [^r]Delete  [/]Search",
+                (false, false) => "[[/]]Page  [j/k]Navigate  [Space]Toggle  [a]Add  [e]Edit  [/]Search",
+                (true, true) => "[[/]]Page  [j/k]Navigate  [Space]Toggle  [a]Add  [e]Edit  [^r]Delete  [Esc]Search",
+                (false, true) => "[[/]]Page  [j/k]Navigate  [Space]Toggle  [a]Add  [e]Edit  [Esc]Search",
+            },
+            TodosMode::Adding | TodosMode::Editing => "[Enter]Confirm  [Esc]Cancel  [Backspace]Delete char",
+            TodosMode::Searching => "[Enter]Confirm search  [Esc]Cancel search",
         };
 
         Paragraph::new(hint).centered().fg(Color::DarkGray).render(area, buf);

--- a/src/widgets/todos/hint.rs
+++ b/src/widgets/todos/hint.rs
@@ -18,7 +18,11 @@ pub struct HintProps {
 impl HintProps {
     /// Creates new hint props from the current mode, delete availability, and search state.
     pub fn new(ui_mode: TodosMode, can_delete: bool, is_searching: bool) -> Self {
-        Self { ui_mode, can_delete, is_searching }
+        Self {
+            ui_mode,
+            can_delete,
+            is_searching,
+        }
     }
 }
 

--- a/src/widgets/todos/hint.rs
+++ b/src/widgets/todos/hint.rs
@@ -11,12 +11,14 @@ pub struct HintProps {
     ui_mode: TodosMode,
     /// Whether the delete action is available for the selected todo.
     can_delete: bool,
+    /// Active search query shown inline; empty string means no search is active.
+    search_query: String,
 }
 
 impl HintProps {
-    /// Creates new hint props from the current mode and delete availability.
-    pub fn new(ui_mode: TodosMode, can_delete: bool) -> Self {
-        Self { ui_mode, can_delete }
+    /// Creates new hint props from the current mode, delete availability, and active search query.
+    pub fn new(ui_mode: TodosMode, can_delete: bool, search_query: String) -> Self {
+        Self { ui_mode, can_delete, search_query }
     }
 }
 
@@ -38,13 +40,23 @@ impl Widget for &HintWidget<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let hint = match self.props.ui_mode {
             TodosMode::Normal => {
-                if self.props.can_delete {
-                    "[[/]]Page  [j/k]Navigate  [Space]Toggle  [a]Add  [e]Edit  [^r]Delete"
+                let base = if self.props.can_delete {
+                    "[[/]]Page  [j/k]Navigate  [Space]Toggle  [a]Add  [e]Edit  [^r]Delete  [/]Search"
                 } else {
-                    "[[/]]Page  [j/k]Navigate  [Space]Toggle  [a]Add  [e]Edit"
+                    "[[/]]Page  [j/k]Navigate  [Space]Toggle  [a]Add  [e]Edit  [/]Search"
+                };
+                if !self.props.search_query.is_empty() {
+                    format!("{}  \"{}\"", base, self.props.search_query)
+                } else {
+                    base.to_string()
                 }
             }
-            TodosMode::Adding | TodosMode::Editing => "[Enter]Confirm  [Esc]Cancel  [Backspace]Delete char",
+            TodosMode::Adding | TodosMode::Editing => {
+                "[Enter]Confirm  [Esc]Cancel  [Backspace]Delete char".to_string()
+            }
+            TodosMode::Searching => {
+                "[Enter]Confirm search  [Esc]Cancel search  [Backspace]Delete char".to_string()
+            }
         };
 
         Paragraph::new(hint).centered().fg(Color::DarkGray).render(area, buf);

--- a/src/widgets/todos/input.rs
+++ b/src/widgets/todos/input.rs
@@ -1,6 +1,6 @@
 use ratatui::{
     crossterm::event::{KeyCode, KeyEvent, KeyModifiers},
-    prelude::{Buffer, Color, Constraint, Frame, Layout, Rect, Style, Stylize, Widget},
+    prelude::{Buffer, Color, Constraint, Layout, Rect, Style, Stylize, Widget},
     text::Span,
     widgets::{Block, Paragraph},
 };
@@ -117,10 +117,10 @@ impl InputState {
         InputAction::None
     }
 
-    /// Renders the calendar overlay into the frame if it is currently open.
-    pub fn render_calendar(&self, frame: &mut Frame, area: Rect) {
+    /// Renders the calendar overlay into the buffer if it is currently open.
+    pub fn render_calendar(&self, area: Rect, buf: &mut Buffer) {
         if let Some(cal) = &self.calendar_state {
-            frame.render_widget(&CalendarWidget::new(cal.props()), area);
+            CalendarWidget::new(cal.props()).render(area, buf);
         }
     }
 }

--- a/src/widgets/todos/mod.rs
+++ b/src/widgets/todos/mod.rs
@@ -16,3 +16,5 @@ pub mod repeat;
 pub mod status;
 /// Page tab bar for switching todo views.
 pub mod tabs;
+/// Search bar widget and state for filtering todos by text.
+pub mod search;

--- a/src/widgets/todos/mod.rs
+++ b/src/widgets/todos/mod.rs
@@ -12,9 +12,9 @@ pub mod item;
 pub mod list;
 /// Repeat-rule picker overlay for recurring todos.
 pub mod repeat;
+/// Search bar widget and state for filtering todos by text.
+pub mod search;
 /// Pagination and list status bar widget.
 pub mod status;
 /// Page tab bar for switching todo views.
 pub mod tabs;
-/// Search bar widget and state for filtering todos by text.
-pub mod search;

--- a/src/widgets/todos/search.rs
+++ b/src/widgets/todos/search.rs
@@ -30,7 +30,10 @@ pub struct SearchProps {
 impl SearchProps {
     /// Creates new search props.
     pub fn new(query: impl Into<String>, active: bool) -> Self {
-        Self { query: query.into(), active }
+        Self {
+            query: query.into(),
+            active,
+        }
     }
 }
 
@@ -42,7 +45,9 @@ pub struct SearchState {
 impl SearchState {
     /// Creates a new `SearchState`, optionally pre-filling with an existing query.
     pub fn new(existing_query: &str) -> Self {
-        Self { props: SearchProps::new(existing_query, true) }
+        Self {
+            props: SearchProps::new(existing_query, true),
+        }
     }
 
     /// Returns a reference to the props for rendering.

--- a/src/widgets/todos/search.rs
+++ b/src/widgets/todos/search.rs
@@ -1,0 +1,79 @@
+use ratatui::{
+    prelude::{Buffer, Rect, Style, Widget},
+    widgets::Block,
+};
+use ratatui_textarea::TextArea;
+
+use crate::tabs::todos::COLOR;
+
+/// Action returned by the search widget after handling a key event.
+pub enum SearchAction {
+    /// User pressed Enter to confirm; keeps the filter active and closes the bar.
+    Confirm,
+    /// User pressed Escape to cancel; clears the filter and closes the bar.
+    Cancel,
+    /// Query text changed; carries the new query string.
+    QueryChanged(String),
+    /// No state change occurred.
+    None,
+}
+
+/// Stateful container for the search bar, owns the textarea.
+pub struct SearchState {
+    /// Textarea holding the current search query as the user types.
+    textarea: TextArea<'static>,
+}
+
+impl SearchState {
+    /// Creates a new `SearchState`, optionally pre-filling with an existing query.
+    pub fn new(existing_query: &str) -> Self {
+        let mut textarea = TextArea::default();
+        if !existing_query.is_empty() {
+            textarea.insert_str(existing_query);
+        }
+        textarea.set_block(
+            Block::bordered()
+                .title(" Search ")
+                .border_style(Style::default().fg(COLOR)),
+        );
+        textarea.set_cursor_line_style(Style::default());
+        Self { textarea }
+    }
+
+    /// Returns a reference to the inner textarea for rendering.
+    pub fn textarea(&self) -> &TextArea<'static> {
+        &self.textarea
+    }
+
+    /// Handles a key event and returns the resulting action.
+    pub fn handle(&mut self, key: ratatui::crossterm::event::KeyEvent) -> SearchAction {
+        use ratatui::crossterm::event::KeyCode;
+        match key.code {
+            KeyCode::Enter => SearchAction::Confirm,
+            KeyCode::Esc => SearchAction::Cancel,
+            _ => {
+                self.textarea.input(key);
+                SearchAction::QueryChanged(self.textarea.lines()[0].clone())
+            }
+        }
+    }
+}
+
+/// Stateless widget that renders the search bar textarea.
+pub struct SearchWidget<'a> {
+    /// Borrowed textarea for this render pass.
+    textarea: &'a TextArea<'static>,
+}
+
+impl<'a> SearchWidget<'a> {
+    /// Creates a new search widget from the given state.
+    pub fn new(state: &'a SearchState) -> Self {
+        Self { textarea: state.textarea() }
+    }
+}
+
+impl Widget for &SearchWidget<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        Widget::render(self.textarea, area, buf);
+    }
+}

--- a/src/widgets/todos/search.rs
+++ b/src/widgets/todos/search.rs
@@ -1,16 +1,17 @@
 use ratatui::{
-    prelude::{Buffer, Rect, Style, Widget},
-    widgets::Block,
+    crossterm::event::{KeyCode, KeyEvent},
+    prelude::{Buffer, Rect, Stylize, Widget},
+    text::{Line, Span},
+    widgets::Paragraph,
 };
-use ratatui_textarea::TextArea;
 
 use crate::tabs::todos::COLOR;
 
-/// Action returned by the search widget after handling a key event.
+/// Action returned by the search state after handling a key event.
 pub enum SearchAction {
-    /// User pressed Enter to confirm; keeps the filter active and closes the bar.
+    /// User pressed Enter; keeps the filter active and closes the bar.
     Confirm,
-    /// User pressed Escape to cancel; clears the filter and closes the bar.
+    /// User pressed Escape; clears the filter and closes the bar.
     Cancel,
     /// Query text changed; carries the new query string.
     QueryChanged(String),
@@ -18,62 +19,76 @@ pub enum SearchAction {
     None,
 }
 
-/// Stateful container for the search bar, owns the textarea.
+/// Props for the search widget.
+pub struct SearchProps {
+    /// The current search query string.
+    pub query: String,
+    /// Whether the search bar is actively being typed into (shows block cursor).
+    pub active: bool,
+}
+
+impl SearchProps {
+    /// Creates new search props.
+    pub fn new(query: impl Into<String>, active: bool) -> Self {
+        Self { query: query.into(), active }
+    }
+}
+
+/// Stateful container for the search bar; owns the query and handles key events.
 pub struct SearchState {
-    /// Textarea holding the current search query as the user types.
-    textarea: TextArea<'static>,
+    props: SearchProps,
 }
 
 impl SearchState {
     /// Creates a new `SearchState`, optionally pre-filling with an existing query.
     pub fn new(existing_query: &str) -> Self {
-        let mut textarea = TextArea::default();
-        if !existing_query.is_empty() {
-            textarea.insert_str(existing_query);
-        }
-        textarea.set_block(
-            Block::bordered()
-                .title(" Search ")
-                .border_style(Style::default().fg(COLOR)),
-        );
-        textarea.set_cursor_line_style(Style::default());
-        Self { textarea }
+        Self { props: SearchProps::new(existing_query, true) }
     }
 
-    /// Returns a reference to the inner textarea for rendering.
-    pub fn textarea(&self) -> &TextArea<'static> {
-        &self.textarea
+    /// Returns a reference to the props for rendering.
+    pub fn props(&self) -> &SearchProps {
+        &self.props
     }
 
     /// Handles a key event and returns the resulting action.
-    pub fn handle(&mut self, key: ratatui::crossterm::event::KeyEvent) -> SearchAction {
-        use ratatui::crossterm::event::KeyCode;
+    pub fn handle(&mut self, key: KeyEvent) -> SearchAction {
         match key.code {
             KeyCode::Enter => SearchAction::Confirm,
             KeyCode::Esc => SearchAction::Cancel,
-            _ => {
-                self.textarea.input(key);
-                SearchAction::QueryChanged(self.textarea.lines()[0].clone())
+            KeyCode::Backspace => {
+                self.props.query.pop();
+                SearchAction::QueryChanged(self.props.query.clone())
             }
+            KeyCode::Char(c) => {
+                self.props.query.push(c);
+                SearchAction::QueryChanged(self.props.query.clone())
+            }
+            _ => SearchAction::None,
         }
     }
 }
 
-/// Stateless widget that renders the search bar textarea.
+/// Stateless widget that renders the search line as `/query` with an optional block cursor.
 pub struct SearchWidget<'a> {
-    /// Borrowed textarea for this render pass.
-    textarea: &'a TextArea<'static>,
+    props: &'a SearchProps,
 }
 
 impl<'a> SearchWidget<'a> {
-    /// Creates a new search widget from the given state.
-    pub fn new(state: &'a SearchState) -> Self {
-        Self { textarea: state.textarea() }
+    /// Creates a new search widget from the given props.
+    pub fn new(props: &'a SearchProps) -> Self {
+        Self { props }
     }
 }
 
 impl Widget for &SearchWidget<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        Widget::render(self.textarea, area, buf);
+        let mut spans = vec![
+            Span::from("/").fg(COLOR).bold(),
+            Span::from(self.props.query.as_str()).fg(COLOR),
+        ];
+        if self.props.active {
+            spans.push(Span::from("█").fg(COLOR));
+        }
+        Paragraph::new(Line::from(spans)).render(area, buf);
     }
 }


### PR DESCRIPTION
## Summary

- Adds vim-style `/` search to the todos tab — press `/` to open the search bar, type to filter, `Enter` to confirm (keeps filter active), `Esc` to cancel
- Disables the `seed` command in release builds (`#[cfg(debug_assertions)]`)
- Switches todos tab border to `BorderWidget` (same as timer tab)
- Improves README: install instructions clarity, shell prompt prefixes on all code blocks, sqlite3 dependency callouts