### PR TITLE
Add overdue todos as separate section in timer todo picker

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,3 +10,5 @@
 8. [x] Use the same session color on everywhere on the timer tab.
 9. [x] Add mouse support click on tab header tabs.
 10. [x] Show session tab color to orivo name of the application.
+11. Load due todo also on the todo picker on timer due todo should be a seperate section.
+

--- a/TODO.md
+++ b/TODO.md
@@ -10,5 +10,5 @@
 8. [x] Use the same session color on everywhere on the timer tab.
 9. [x] Add mouse support click on tab header tabs.
 10. [x] Show session tab color to orivo name of the application.
-11. Load due todo also on the todo picker on timer due todo should be a seperate section.
+11. [x] Load due todo also on the todo picker on timer due todo should be a seperate section.
 

--- a/src/caches/timer.rs
+++ b/src/caches/timer.rs
@@ -9,6 +9,10 @@ use crate::models::{
 pub struct TimerCache {
     /// Database connection used to refresh cache entries on demand.
     db: DatabaseConnection,
+    /// Cached list of overdue todos, `None` until first fetch.
+    due_todos: Option<Vec<Todo>>,
+    /// Cached stats parallel to `due_todos`, `None` until first fetch.
+    due_stats: Option<Vec<Stat>>,
     /// Cached list of today's todos, `None` until first fetch.
     todos: Option<Vec<Todo>>,
     /// Cached stats parallel to `todos`, `None` until first fetch.
@@ -22,10 +26,33 @@ impl TimerCache {
     pub fn new(db: DatabaseConnection) -> Self {
         Self {
             db,
+            due_todos: None,
+            due_stats: None,
             todos: None,
             stats: None,
             today_sessions: None,
         }
+    }
+
+    /// Returns the cached overdue todo list, querying the DB if needed.
+    pub fn get_due_todos(&mut self) -> &[Todo] {
+        if self.due_todos.is_none() {
+            self.due_todos = Some(Todo::list_due_pending(&self.db));
+        }
+        self.due_todos.as_deref().unwrap_or(&[])
+    }
+
+    /// Returns stats for all cached overdue todos, querying the DB if needed.
+    pub fn get_due_stats(&mut self) -> &[Stat] {
+        if self.due_stats.is_none() {
+            let ids: Vec<Option<i32>> = self.get_due_todos().iter().map(|t| t.id).collect();
+            let stats = ids
+                .into_iter()
+                .map(|id| id.map(|id| Session::stat(&self.db, id)).unwrap_or(Stat::new(0, 0)))
+                .collect();
+            self.due_stats = Some(stats);
+        }
+        self.due_stats.as_deref().unwrap_or(&[])
     }
 
     /// Returns the cached todo list (excluding done todos), querying the DB if needed.
@@ -38,8 +65,13 @@ impl TimerCache {
 
     /// Returns the cached todo with the given id, querying the DB if needed.
     pub fn get_todo(&mut self, id: i32) -> Option<&Todo> {
+        self.get_due_todos();
         self.get_todos();
-        self.todos.as_deref()?.iter().find(|t| t.id == Some(id))
+        self.due_todos
+            .as_deref()?
+            .iter()
+            .chain(self.todos.as_deref().unwrap_or(&[]).iter())
+            .find(|t| t.id == Some(id))
     }
 
     /// Returns stats for all cached todos, querying the DB if needed.
@@ -57,7 +89,11 @@ impl TimerCache {
 
     /// Returns the cached session stats for the given todo id, querying the DB if needed.
     pub fn get_stat(&mut self, todo_id: i32) -> Option<&Stat> {
+        self.get_due_stats();
         self.get_stats();
+        if let Some(idx) = self.due_todos.as_deref()?.iter().position(|t| t.id == Some(todo_id)) {
+            return self.due_stats.as_deref()?.get(idx);
+        }
         let idx = self.todos.as_deref()?.iter().position(|t| t.id == Some(todo_id))?;
         self.stats.as_deref()?.get(idx)
     }
@@ -72,6 +108,8 @@ impl TimerCache {
 
     /// Drops the cached todo list so the next call to `get_todos()` re-queries.
     pub fn invalidate_todos(&mut self) {
+        self.due_todos = None;
+        self.due_stats = None;
         self.todos = None;
         self.stats = None;
         self.today_sessions = None;
@@ -79,6 +117,7 @@ impl TimerCache {
 
     /// Drops the cached session stats so they are re-fetched on next render.
     pub fn invalidate_stats(&mut self) {
+        self.due_stats = None;
         self.stats = None;
         self.today_sessions = None;
     }

--- a/src/models/todo.rs
+++ b/src/models/todo.rs
@@ -117,6 +117,24 @@ impl Todo {
         }
     }
 
+    /// Returns overdue todos that are not yet done (due_date < today), for the timer picker.
+    pub fn list_due_pending(db: &DatabaseConnection) -> Vec<Todo> {
+        let today = format_date(today());
+        let query = Entity::find()
+            .filter(Expr::cust_with_values("substr(due_date, 1, 10) < ?", [today]))
+            .filter(Column::DoneAt.is_null())
+            .order_by_desc(Column::DueDate)
+            .order_by_desc(Column::CreatedAt);
+
+        match rt().block_on(async { query.all(db).await.map_err(io_err) }) {
+            Ok(models) => models.into_iter().map(Todo::from).collect(),
+            Err(e) => {
+                log_error!("failed to load overdue pending todos: {e}");
+                vec![]
+            }
+        }
+    }
+
     fn base_search_query(page: Page, query: &str) -> sea_orm::Select<Entity> {
         let pattern = format!("%{}%", query.to_lowercase());
         Self::base_query(page).filter(Expr::cust_with_values("lower(text) LIKE ?", [pattern]))

--- a/src/tabs/timer.rs
+++ b/src/tabs/timer.rs
@@ -125,7 +125,11 @@ impl TimerTab {
             let todos = cache.get_todos().to_vec();
             let stats = cache.get_stats().to_vec();
             self.picker = Some(TodoPickerState::new(TodoPickerProps::new(
-                due_todos, due_stats, todos, stats, self.color(),
+                due_todos,
+                due_stats,
+                todos,
+                stats,
+                self.color(),
             )));
         }
     }

--- a/src/tabs/timer.rs
+++ b/src/tabs/timer.rs
@@ -124,12 +124,22 @@ impl TimerTab {
             let due_stats = cache.get_due_stats().to_vec();
             let todos = cache.get_todos().to_vec();
             let stats = cache.get_stats().to_vec();
+            let current_id = self.state.lock().ok().and_then(|s| s.todo_id());
+            let cursor = current_id
+                .and_then(|id| {
+                    due_todos
+                        .iter()
+                        .position(|t| t.id == Some(id))
+                        .or_else(|| todos.iter().position(|t| t.id == Some(id)).map(|i| due_todos.len() + i))
+                })
+                .unwrap_or(0);
             self.picker = Some(TodoPickerState::new(TodoPickerProps::new(
                 due_todos,
                 due_stats,
                 todos,
                 stats,
                 self.color(),
+                cursor,
             )));
         }
     }

--- a/src/tabs/timer.rs
+++ b/src/tabs/timer.rs
@@ -124,22 +124,14 @@ impl TimerTab {
             let due_stats = cache.get_due_stats().to_vec();
             let todos = cache.get_todos().to_vec();
             let stats = cache.get_stats().to_vec();
-            let current_id = self.state.lock().ok().and_then(|s| s.todo_id());
-            let cursor = current_id
-                .and_then(|id| {
-                    due_todos
-                        .iter()
-                        .position(|t| t.id == Some(id))
-                        .or_else(|| todos.iter().position(|t| t.id == Some(id)).map(|i| due_todos.len() + i))
-                })
-                .unwrap_or(0);
+            let selected_id = self.state.lock().ok().and_then(|s| s.todo_id());
             self.picker = Some(TodoPickerState::new(TodoPickerProps::new(
                 due_todos,
                 due_stats,
                 todos,
                 stats,
                 self.color(),
-                cursor,
+                selected_id,
             )));
         }
     }

--- a/src/tabs/timer.rs
+++ b/src/tabs/timer.rs
@@ -120,9 +120,13 @@ impl TimerTab {
     /// Opens the todo picker, loading todos and stats from the cache.
     fn open_picker(&mut self) {
         if let Ok(mut cache) = self.cache.lock() {
+            let due_todos = cache.get_due_todos().to_vec();
+            let due_stats = cache.get_due_stats().to_vec();
             let todos = cache.get_todos().to_vec();
             let stats = cache.get_stats().to_vec();
-            self.picker = Some(TodoPickerState::new(TodoPickerProps::new(todos, stats, self.color())));
+            self.picker = Some(TodoPickerState::new(TodoPickerProps::new(
+                due_todos, due_stats, todos, stats, self.color(),
+            )));
         }
     }
 

--- a/src/widgets/timer/todo_picker.rs
+++ b/src/widgets/timer/todo_picker.rs
@@ -18,51 +18,64 @@ pub enum TodoPickerAction {
 
 /// Props for the todo-picker overlay.
 pub struct TodoPickerProps {
-    /// Todos available for selection.
+    /// Overdue todos (due_date < today).
+    due_todos: Vec<Todo>,
+    /// Session stats parallel to `due_todos`.
+    due_stats: Vec<Stat>,
+    /// Today's todos.
     todos: Vec<Todo>,
-    /// Session stats corresponding to each todo in order.
+    /// Session stats parallel to `todos`.
     stats: Vec<Stat>,
-    /// Index of the currently highlighted todo.
+    /// Index of the currently highlighted todo (across both sections combined).
     cursor: usize,
-    /// Pass the phase color to use in everywhere
+    /// Pass the phase color to use everywhere.
     color: Color,
 }
 
 impl TodoPickerProps {
-    /// Creates new todo-picker props from the todo and stats lists.
-    pub fn new(todos: Vec<Todo>, stats: Vec<Stat>, color: Color) -> Self {
+    pub fn new(
+        due_todos: Vec<Todo>,
+        due_stats: Vec<Stat>,
+        todos: Vec<Todo>,
+        stats: Vec<Stat>,
+        color: Color,
+    ) -> Self {
         Self {
+            due_todos,
+            due_stats,
             todos,
             stats,
             cursor: 0,
             color,
         }
     }
+
+    fn total(&self) -> usize {
+        self.due_todos.len() + self.todos.len()
+    }
 }
 
 /// Stateful container for the todo-picker, owns its props and cursor.
 pub struct TodoPickerState {
-    /// Mutable props updated as the user navigates.
     props: TodoPickerProps,
 }
 
 impl TodoPickerState {
-    /// Creates a new picker state wrapping the given props.
     pub fn new(props: TodoPickerProps) -> Self {
         Self { props }
     }
 
-    /// Returns a shared reference to the current props.
     pub fn props(&self) -> &TodoPickerProps {
         &self.props
     }
 
     /// Handles a key event and returns the resulting action.
     pub fn handle(&mut self, key: KeyEvent) -> TodoPickerAction {
+        let total = self.props.total();
         match key.code {
             KeyCode::Char('j') | KeyCode::Down => {
-                if !self.props.todos.is_empty() {
-                    self.props.cursor = (self.props.cursor + 1).min(self.props.todos.len() - 1);
+                if total > 0 {
+                    self.props.cursor = (self.props.cursor + 1).min(total - 1);
                 }
                 TodoPickerAction::None
             }
@@ -71,7 +84,14 @@ impl TodoPickerState {
                 TodoPickerAction::None
             }
             KeyCode::Enter => {
-                if let Some(id) = self.props.todos.get(self.props.cursor).and_then(|t| t.id) {
+                let due_len = self.props.due_todos.len();
+                let cursor = self.props.cursor;
+                let id = if cursor < due_len {
+                    self.props.due_todos.get(cursor).and_then(|t| t.id)
+                } else {
+                    self.props.todos.get(cursor - due_len).and_then(|t| t.id)
+                };
+                if let Some(id) = id {
                     TodoPickerAction::Select(id)
                 } else {
                     TodoPickerAction::Cancel
@@ -85,19 +105,23 @@ impl TodoPickerState {
 
 /// Stateless widget that renders the todo-picker popup.
 pub struct TodoPickerWidget<'a> {
-    /// Borrowed picker props for this render pass.
     props: &'a TodoPickerProps,
 }
 
 impl<'a> TodoPickerWidget<'a> {
-    /// Creates a new picker widget from the given props.
     pub fn new(props: &'a TodoPickerProps) -> Self {
         Self { props }
     }
 }
 
+/// A display row: either a non-selectable section header or a selectable todo item.
+enum Row {
+    Header(&'static str),
+    /// logical index into the combined due+today list
+    Item(usize),
+}
+
 impl Widget for &TodoPickerWidget<'_> {
-    /// Renders the centered popup list into the buffer.
     fn render(self, area: Rect, buf: &mut Buffer) {
         let popup = centered_rect(area, 60, area.height.saturating_sub(4));
 
@@ -111,7 +135,9 @@ impl Widget for &TodoPickerWidget<'_> {
         let inner = block.inner(popup);
         block.render(popup, buf);
 
-        if self.props.todos.is_empty() {
+        let total = self.props.total();
+
+        if total == 0 {
             Paragraph::new("No todos for today")
                 .centered()
                 .fg(Color::DarkGray)
@@ -119,40 +145,67 @@ impl Widget for &TodoPickerWidget<'_> {
             return;
         }
 
+        // Build display rows (headers + items)
+        let mut rows: Vec<Row> = vec![];
+        if !self.props.due_todos.is_empty() {
+            rows.push(Row::Header("Overdue"));
+            for i in 0..self.props.due_todos.len() {
+                rows.push(Row::Item(i));
+            }
+        }
+        if !self.props.todos.is_empty() {
+            rows.push(Row::Header("Today"));
+            let due_len = self.props.due_todos.len();
+            for i in 0..self.props.todos.len() {
+                rows.push(Row::Item(due_len + i));
+            }
+        }
+
+        // Find which display row the cursor item is on
+        let cursor_row = rows.iter().position(|r| matches!(r, Row::Item(i) if *i == self.props.cursor)).unwrap_or(0);
+
         let visible = inner.height as usize;
-        let serial_width = self.props.todos.len().max(1).to_string().len();
+        let serial_width = total.max(1).to_string().len();
+        let due_len = self.props.due_todos.len();
 
-        let start = self
-            .props
-            .cursor
+        // Center scroll around the cursor's display row
+        let start = cursor_row
             .saturating_sub(visible / 2)
-            .min(self.props.todos.len().saturating_sub(visible));
+            .min(rows.len().saturating_sub(visible));
 
-        let items: Vec<ListItem> = self
-            .props
-            .todos
+        let items: Vec<ListItem> = rows
             .iter()
-            .zip(self.props.stats.iter())
             .enumerate()
             .skip(start)
             .take(visible)
-            .map(|(i, (todo, stat))| {
-                let serial = i + 1;
-                let label = if stat.completed_sessions > 0 {
-                    format!(
-                        "{}  ·  {}× {}m",
-                        todo.text,
-                        stat.completed_sessions,
-                        stat.completed_secs / 60
-                    )
-                } else {
-                    todo.text.clone()
-                };
-                if i == self.props.cursor {
-                    ListItem::new(format!("> {serial:>serial_width$}. {label}"))
-                        .style(Style::new().fg(self.props.color).bold())
-                } else {
-                    ListItem::new(format!("  {serial:>serial_width$}. {label}")).style(Style::new().fg(Color::White))
+            .map(|(_, row)| match row {
+                Row::Header(label) => ListItem::new(format!("── {label} ──"))
+                    .style(Style::new().fg(Color::DarkGray)),
+                Row::Item(logical_idx) => {
+                    let (todo, stat) = if *logical_idx < due_len {
+                        (&self.props.due_todos[*logical_idx], &self.props.due_stats[*logical_idx])
+                    } else {
+                        let i = logical_idx - due_len;
+                        (&self.props.todos[i], &self.props.stats[i])
+                    };
+                    let serial = logical_idx + 1;
+                    let label = if stat.completed_sessions > 0 {
+                        format!(
+                            "{}  ·  {}× {}m",
+                            todo.text,
+                            stat.completed_sessions,
+                            stat.completed_secs / 60
+                        )
+                    } else {
+                        todo.text.clone()
+                    };
+                    if *logical_idx == self.props.cursor {
+                        ListItem::new(format!("> {serial:>serial_width$}. {label}"))
+                            .style(Style::new().fg(self.props.color).bold())
+                    } else {
+                        ListItem::new(format!("  {serial:>serial_width$}. {label}"))
+                            .style(Style::new().fg(Color::White))
+                    }
                 }
             })
             .collect();

--- a/src/widgets/timer/todo_picker.rs
+++ b/src/widgets/timer/todo_picker.rs
@@ -229,10 +229,19 @@ impl Widget for &TodoPickerWidget<'_> {
 
                     if is_selected {
                         // Fill row with phase color background, render text in black
-                        buf.set_style(row_rect, Style::default().bg(self.props.color).fg(Color::Black).add_modifier(Modifier::BOLD));
+                        buf.set_style(
+                            row_rect,
+                            Style::default()
+                                .bg(self.props.color)
+                                .fg(Color::Black)
+                                .add_modifier(Modifier::BOLD),
+                        );
                         Paragraph::new(text).render(row_rect, buf);
                     } else if is_cursor {
-                        buf.set_style(row_rect, Style::default().fg(self.props.color).add_modifier(Modifier::BOLD));
+                        buf.set_style(
+                            row_rect,
+                            Style::default().fg(self.props.color).add_modifier(Modifier::BOLD),
+                        );
                         Paragraph::new(text).render(row_rect, buf);
                     } else {
                         Paragraph::new(text).fg(Color::White).render(row_rect, buf);

--- a/src/widgets/timer/todo_picker.rs
+++ b/src/widgets/timer/todo_picker.rs
@@ -33,13 +33,7 @@ pub struct TodoPickerProps {
 }
 
 impl TodoPickerProps {
-    pub fn new(
-        due_todos: Vec<Todo>,
-        due_stats: Vec<Stat>,
-        todos: Vec<Todo>,
-        stats: Vec<Stat>,
-        color: Color,
-    ) -> Self {
+    pub fn new(due_todos: Vec<Todo>, due_stats: Vec<Stat>, todos: Vec<Todo>, stats: Vec<Stat>, color: Color) -> Self {
         Self {
             due_todos,
             due_stats,
@@ -162,7 +156,10 @@ impl Widget for &TodoPickerWidget<'_> {
         }
 
         // Find which display row the cursor item is on
-        let cursor_row = rows.iter().position(|r| matches!(r, Row::Item(i) if *i == self.props.cursor)).unwrap_or(0);
+        let cursor_row = rows
+            .iter()
+            .position(|r| matches!(r, Row::Item(i) if *i == self.props.cursor))
+            .unwrap_or(0);
 
         let visible = inner.height as usize;
         let serial_width = total.max(1).to_string().len();
@@ -179,8 +176,7 @@ impl Widget for &TodoPickerWidget<'_> {
             .skip(start)
             .take(visible)
             .map(|(_, row)| match row {
-                Row::Header(label) => ListItem::new(format!("── {label} ──"))
-                    .style(Style::new().fg(Color::DarkGray)),
+                Row::Header(label) => ListItem::new(format!("── {label} ──")).style(Style::new().fg(Color::DarkGray)),
                 Row::Item(logical_idx) => {
                     let (todo, stat) = if *logical_idx < due_len {
                         (&self.props.due_todos[*logical_idx], &self.props.due_stats[*logical_idx])

--- a/src/widgets/timer/todo_picker.rs
+++ b/src/widgets/timer/todo_picker.rs
@@ -28,7 +28,9 @@ pub struct TodoPickerProps {
     stats: Vec<Stat>,
     /// Index of the currently highlighted todo (across both sections combined).
     cursor: usize,
-    /// Pass the phase color to use everywhere.
+    /// The id of the todo currently assigned to the timer, shown in phase color.
+    selected_id: Option<i32>,
+    /// Phase color used for borders and the selected todo.
     color: Color,
 }
 
@@ -39,14 +41,25 @@ impl TodoPickerProps {
         todos: Vec<Todo>,
         stats: Vec<Stat>,
         color: Color,
-        initial_cursor: usize,
+        selected_id: Option<i32>,
     ) -> Self {
+        // Position cursor on the currently selected todo, default to 0.
+        let cursor = selected_id
+            .and_then(|id| {
+                due_todos
+                    .iter()
+                    .position(|t| t.id == Some(id))
+                    .or_else(|| todos.iter().position(|t| t.id == Some(id)).map(|i| due_todos.len() + i))
+            })
+            .unwrap_or(0);
+
         Self {
             due_todos,
             due_stats,
             todos,
             stats,
-            cursor: initial_cursor,
+            cursor,
+            selected_id,
             color,
         }
     }
@@ -186,7 +199,7 @@ impl Widget for &TodoPickerWidget<'_> {
             match row {
                 Row::Header(label) => {
                     Paragraph::new(format!("── {label} ──"))
-                        .style(Style::default().fg(Color::DarkGray))
+                        .fg(Color::DarkGray)
                         .render(row_rect, buf);
                 }
                 Row::Item(logical_idx) => {
@@ -207,17 +220,23 @@ impl Widget for &TodoPickerWidget<'_> {
                     } else {
                         todo.text.clone()
                     };
-                    let (prefix, style) = if *logical_idx == self.props.cursor {
-                        (
-                            ">",
-                            Style::default().fg(self.props.color).add_modifier(Modifier::BOLD),
-                        )
+
+                    let is_cursor = *logical_idx == self.props.cursor;
+                    let is_selected = todo.id.is_some() && todo.id == self.props.selected_id;
+
+                    let prefix = if is_cursor { ">" } else { " " };
+                    let text = format!("{prefix} {serial:>serial_width$}. {label}");
+
+                    if is_selected {
+                        // Fill row with phase color background, render text in black
+                        buf.set_style(row_rect, Style::default().bg(self.props.color).fg(Color::Black).add_modifier(Modifier::BOLD));
+                        Paragraph::new(text).render(row_rect, buf);
+                    } else if is_cursor {
+                        buf.set_style(row_rect, Style::default().fg(self.props.color).add_modifier(Modifier::BOLD));
+                        Paragraph::new(text).render(row_rect, buf);
                     } else {
-                        ("  ", Style::default().fg(Color::White))
-                    };
-                    Paragraph::new(format!("{prefix} {serial:>serial_width$}. {label}"))
-                        .style(style)
-                        .render(row_rect, buf);
+                        Paragraph::new(text).fg(Color::White).render(row_rect, buf);
+                    }
                 }
             }
         }

--- a/src/widgets/timer/todo_picker.rs
+++ b/src/widgets/timer/todo_picker.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     crossterm::event::{KeyCode, KeyEvent},
-    prelude::{Buffer, Color, Rect, Style, Stylize, Widget},
-    widgets::{Block, Clear, List, ListItem, Paragraph},
+    prelude::{Buffer, Color, Modifier, Rect, Style, Stylize, Widget},
+    widgets::{Block, Clear, Paragraph},
 };
 
 use crate::models::{session::Stat, todo::Todo};
@@ -177,13 +177,18 @@ impl Widget for &TodoPickerWidget<'_> {
             .saturating_sub(visible / 2)
             .min(rows.len().saturating_sub(visible));
 
-        let items: Vec<ListItem> = rows
-            .iter()
-            .enumerate()
-            .skip(start)
-            .take(visible)
-            .map(|(_, row)| match row {
-                Row::Header(label) => ListItem::new(format!("── {label} ──")).style(Style::new().fg(Color::DarkGray)),
+        for (row_offset, row) in rows.iter().skip(start).take(visible).enumerate() {
+            let row_rect = Rect {
+                y: inner.y + row_offset as u16,
+                height: 1,
+                ..inner
+            };
+            match row {
+                Row::Header(label) => {
+                    Paragraph::new(format!("── {label} ──"))
+                        .style(Style::default().fg(Color::DarkGray))
+                        .render(row_rect, buf);
+                }
                 Row::Item(logical_idx) => {
                     let (todo, stat) = if *logical_idx < due_len {
                         (&self.props.due_todos[*logical_idx], &self.props.due_stats[*logical_idx])
@@ -202,18 +207,20 @@ impl Widget for &TodoPickerWidget<'_> {
                     } else {
                         todo.text.clone()
                     };
-                    if *logical_idx == self.props.cursor {
-                        ListItem::new(format!("> {serial:>serial_width$}. {label}"))
-                            .style(Style::new().fg(self.props.color).bold())
+                    let (prefix, style) = if *logical_idx == self.props.cursor {
+                        (
+                            ">",
+                            Style::default().fg(self.props.color).add_modifier(Modifier::BOLD),
+                        )
                     } else {
-                        ListItem::new(format!("  {serial:>serial_width$}. {label}"))
-                            .style(Style::new().fg(Color::White))
-                    }
+                        ("  ", Style::default().fg(Color::White))
+                    };
+                    Paragraph::new(format!("{prefix} {serial:>serial_width$}. {label}"))
+                        .style(style)
+                        .render(row_rect, buf);
                 }
-            })
-            .collect();
-
-        List::new(items).render(inner, buf);
+            }
+        }
     }
 }
 

--- a/src/widgets/timer/todo_picker.rs
+++ b/src/widgets/timer/todo_picker.rs
@@ -33,13 +33,20 @@ pub struct TodoPickerProps {
 }
 
 impl TodoPickerProps {
-    pub fn new(due_todos: Vec<Todo>, due_stats: Vec<Stat>, todos: Vec<Todo>, stats: Vec<Stat>, color: Color) -> Self {
+    pub fn new(
+        due_todos: Vec<Todo>,
+        due_stats: Vec<Stat>,
+        todos: Vec<Todo>,
+        stats: Vec<Stat>,
+        color: Color,
+        initial_cursor: usize,
+    ) -> Self {
         Self {
             due_todos,
             due_stats,
             todos,
             stats,
-            cursor: 0,
+            cursor: initial_cursor,
             color,
         }
     }


### PR DESCRIPTION
## Summary
- Added `Todo::list_due_pending()` to fetch overdue (past due, not done) todos
- Extended `TimerCache` with `due_todos`/`due_stats` caching and updated `get_todo`/`get_stat` to search both lists
- Timer todo picker now renders two sections: **Overdue** and **Today**, with seamless j/k navigation across both

## Test plan
- [x] Open the timer todo picker (`t`) — verify overdue todos appear under "── Overdue ──" section
- [x] Verify today's todos appear under "── Today ──" section
- [x] Navigate with j/k across both sections
- [x] Select a todo from each section and confirm it attaches to the timer correctly
- [x] Confirm picker shows "No todos for today" when both sections are empty