### PR TITLE
Separate date/repeat pickers and fix due todo repeat scheduling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,4 +11,4 @@
 9. [x] Add mouse support click on tab header tabs.
 10. [x] Show session tab color to orivo name of the application.
 11. [x] Load due todo also on the todo picker on timer due todo should be a seperate section.
-
+12. [ ] seperate the date picker and repeat picker on edit and add as well of todos.

--- a/TODO.md
+++ b/TODO.md
@@ -12,3 +12,5 @@
 10. [x] Show session tab color to orivo name of the application.
 11. [x] Load due todo also on the todo picker on timer due todo should be a seperate section.
 12. [ ] seperate the date picker and repeat picker on edit and add as well of todos.
+13. [ ] when makeing todo toggle the next day can't be today for due todos. it should next validate day after today.
+

--- a/src/models/todo.rs
+++ b/src/models/todo.rs
@@ -77,7 +77,11 @@ impl Todo {
             return None;
         };
 
-        let next_date = repeat.next_date(due_date.date());
+        let mut next_date = repeat.next_date(due_date.date());
+        let today_date = today();
+        while next_date <= today_date {
+            next_date = repeat.next_date(next_date);
+        }
         let next_date_str = format_date(next_date);
         let parent_id = self.id;
 

--- a/src/tabs/todos.rs
+++ b/src/tabs/todos.rs
@@ -260,6 +260,7 @@ impl Tab for TodosTab {
                     if let Some(input_state) = &self.input_state {
                         InputWidget::new(input_state.props()).render(bottom_rect, buf);
                         input_state.render_calendar(area, buf);
+                        input_state.render_repeat(area, buf);
                     }
                 }
                 TodosMode::Searching => {

--- a/src/widgets/todos/calendar.rs
+++ b/src/widgets/todos/calendar.rs
@@ -10,17 +10,14 @@ use ratatui::{
 use time::{Date, Duration};
 
 use crate::{
-    kinds::repeat::Repeat,
     tabs::todos::COLOR,
     utils::date::{shift_month, today},
 };
 
-use super::repeat::{RepeatAction, RepeatProps, RepeatState, RepeatWidget};
-
 /// Action returned by the calendar picker after handling a key event.
 pub enum CalendarAction {
-    /// User confirmed; carries the selected date and optional repeat rule.
-    Confirm { date: Option<Date>, repeat: Option<Repeat> },
+    /// User confirmed; carries the selected date (None = clear date).
+    Confirm { date: Option<Date> },
     /// User cancelled without confirming.
     Cancel,
     /// No state change occurred.
@@ -31,19 +28,13 @@ pub enum CalendarAction {
 pub struct CalendarProps {
     /// Currently highlighted date in the calendar.
     date: Date,
-    /// Optional repeat rule attached to the todo.
-    repeat: Option<Repeat>,
-    /// Active repeat-picker sub-state when the repeat overlay is open.
-    repeat_state: Option<RepeatState>,
 }
 
 impl CalendarProps {
-    /// Creates new calendar props from an optional existing date and repeat rule.
-    pub fn new(date: Option<Date>, repeat: Option<&Repeat>) -> Self {
+    /// Creates new calendar props from an optional existing date.
+    pub fn new(date: Option<Date>) -> Self {
         Self {
             date: date.unwrap_or_else(today),
-            repeat: repeat.map(Repeat::of),
-            repeat_state: None,
         }
     }
 }
@@ -67,26 +58,8 @@ impl CalendarState {
 
     /// Handles a key event and returns the resulting calendar action.
     pub fn handle(&mut self, key: KeyEvent) -> CalendarAction {
-        if let Some(ref mut repeat_picker) = self.props.repeat_state {
-            match repeat_picker.handle(key) {
-                RepeatAction::Confirm(repeat) => {
-                    self.props.repeat = repeat;
-                    self.props.repeat_state = None;
-                    return CalendarAction::Confirm {
-                        date: Some(self.props.date),
-                        repeat: self.props.repeat.as_ref().map(Repeat::of),
-                    };
-                }
-                RepeatAction::Cancel => {
-                    self.props.repeat_state = None;
-                }
-                RepeatAction::None => {}
-            }
-            return CalendarAction::None;
-        }
-
         match key.code {
-            KeyCode::Char('x') => self.navigate(None),
+            KeyCode::Char('x') => return CalendarAction::Confirm { date: None },
             KeyCode::Char('t') => self.navigate(Some(today())),
             KeyCode::Char('y') => self.navigate(today().previous_day()),
             KeyCode::Char('n') => self.navigate(today().next_day()),
@@ -96,18 +69,8 @@ impl CalendarState {
             KeyCode::Char('j') | KeyCode::Down => self.navigate(self.props.date.checked_add(Duration::weeks(1))),
             KeyCode::Char('H') => self.navigate(Some(shift_month(self.props.date, -1))),
             KeyCode::Char('L') => self.navigate(Some(shift_month(self.props.date, 1))),
-            KeyCode::Char('r') => {
-                self.props.repeat_state = Some(RepeatState::new(RepeatProps::new(self.props.repeat.as_ref())));
-            }
-            KeyCode::Enter => {
-                return CalendarAction::Confirm {
-                    date: Some(self.props.date),
-                    repeat: None,
-                };
-            }
-            KeyCode::Esc => {
-                return CalendarAction::Cancel;
-            }
+            KeyCode::Enter => return CalendarAction::Confirm { date: Some(self.props.date) },
+            KeyCode::Esc => return CalendarAction::Cancel,
             _ => {}
         }
         CalendarAction::None
@@ -135,9 +98,9 @@ impl<'a> CalendarWidget<'a> {
 }
 
 impl Widget for &CalendarWidget<'_> {
-    /// Renders the calendar popup (or repeat sub-picker) into the buffer.
+    /// Renders the calendar date-picker popup into the buffer.
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let popup = centered_rect(area, 24, 5 + 10 + 3 + 5);
+        let popup = centered_rect(area, 24, 5 + 10 + 5);
 
         Clear.render(popup, buf);
 
@@ -151,15 +114,9 @@ impl Widget for &CalendarWidget<'_> {
         let mut events = CalendarEventStore::today(Style::default().fg(Color::Yellow).bold());
         events.add(self.props.date, Style::default().bg(COLOR).fg(Color::Black));
 
-        if let Some(repeat_state) = &self.props.repeat_state {
-            RepeatWidget::new(repeat_state.props()).render(inner, buf);
-            return;
-        }
-
-        let [action_hint, cal_area, action_hint2, nav_hint] = Layout::vertical([
+        let [action_hint, cal_area, nav_hint] = Layout::vertical([
             Constraint::Length(5),
             Constraint::Length(10),
-            Constraint::Length(3),
             Constraint::Length(5),
         ])
         .areas(inner);
@@ -181,14 +138,6 @@ impl Widget for &CalendarWidget<'_> {
             .show_month_header(Style::default().bold())
             .show_weekdays_header(Style::default().fg(Color::DarkGray))
             .render(cal_area, buf);
-
-        Paragraph::new("[r]Repeat\n")
-            .block(
-                Block::default()
-                    .borders(Borders::TOP | Borders::BOTTOM)
-                    .border_style(Style::default().fg(COLOR)),
-            )
-            .render(action_hint2, buf);
 
         Paragraph::new(
             "[h/l]Day\n\

--- a/src/widgets/todos/calendar.rs
+++ b/src/widgets/todos/calendar.rs
@@ -17,7 +17,7 @@ use crate::{
 /// Action returned by the calendar picker after handling a key event.
 pub enum CalendarAction {
     /// User confirmed; carries the selected date (None = clear date).
-    Confirm { date: Option<Date> },
+    Confirm(Option<Date>),
     /// User cancelled without confirming.
     Cancel,
     /// No state change occurred.
@@ -59,7 +59,7 @@ impl CalendarState {
     /// Handles a key event and returns the resulting calendar action.
     pub fn handle(&mut self, key: KeyEvent) -> CalendarAction {
         match key.code {
-            KeyCode::Char('x') => return CalendarAction::Confirm { date: None },
+            KeyCode::Char('x') => return CalendarAction::Confirm(None),
             KeyCode::Char('t') => self.navigate(Some(today())),
             KeyCode::Char('y') => self.navigate(today().previous_day()),
             KeyCode::Char('n') => self.navigate(today().next_day()),
@@ -69,11 +69,7 @@ impl CalendarState {
             KeyCode::Char('j') | KeyCode::Down => self.navigate(self.props.date.checked_add(Duration::weeks(1))),
             KeyCode::Char('H') => self.navigate(Some(shift_month(self.props.date, -1))),
             KeyCode::Char('L') => self.navigate(Some(shift_month(self.props.date, 1))),
-            KeyCode::Enter => {
-                return CalendarAction::Confirm {
-                    date: Some(self.props.date),
-                };
-            }
+            KeyCode::Enter => return CalendarAction::Confirm(Some(self.props.date)),
             KeyCode::Esc => return CalendarAction::Cancel,
             _ => {}
         }

--- a/src/widgets/todos/calendar.rs
+++ b/src/widgets/todos/calendar.rs
@@ -69,7 +69,11 @@ impl CalendarState {
             KeyCode::Char('j') | KeyCode::Down => self.navigate(self.props.date.checked_add(Duration::weeks(1))),
             KeyCode::Char('H') => self.navigate(Some(shift_month(self.props.date, -1))),
             KeyCode::Char('L') => self.navigate(Some(shift_month(self.props.date, 1))),
-            KeyCode::Enter => return CalendarAction::Confirm { date: Some(self.props.date) },
+            KeyCode::Enter => {
+                return CalendarAction::Confirm {
+                    date: Some(self.props.date),
+                };
+            }
             KeyCode::Esc => return CalendarAction::Cancel,
             _ => {}
         }
@@ -114,12 +118,8 @@ impl Widget for &CalendarWidget<'_> {
         let mut events = CalendarEventStore::today(Style::default().fg(Color::Yellow).bold());
         events.add(self.props.date, Style::default().bg(COLOR).fg(Color::Black));
 
-        let [action_hint, cal_area, nav_hint] = Layout::vertical([
-            Constraint::Length(5),
-            Constraint::Length(10),
-            Constraint::Length(5),
-        ])
-        .areas(inner);
+        let [action_hint, cal_area, nav_hint] =
+            Layout::vertical([Constraint::Length(5), Constraint::Length(10), Constraint::Length(5)]).areas(inner);
 
         Paragraph::new(
             "[x]No Date\n\

--- a/src/widgets/todos/input.rs
+++ b/src/widgets/todos/input.rs
@@ -222,6 +222,9 @@ impl Widget for &InputWidget<'_> {
             .border_style(Style::default().fg(COLOR));
         let repeat_inner = repeat_block.inner(repeat_area);
         repeat_block.render(repeat_area, buf);
-        Paragraph::new(repeat_str).fg(COLOR).centered().render(repeat_inner, buf);
+        Paragraph::new(repeat_str)
+            .fg(COLOR)
+            .centered()
+            .render(repeat_inner, buf);
     }
 }

--- a/src/widgets/todos/input.rs
+++ b/src/widgets/todos/input.rs
@@ -87,7 +87,7 @@ impl InputState {
     pub fn handle(&mut self, key: KeyEvent) -> InputAction {
         if let Some(cal) = &mut self.calendar_state {
             match cal.handle(key) {
-                CalendarAction::Confirm { date } => {
+                CalendarAction::Confirm(date) => {
                     self.props.date = date.map(|d| now().replace_date(d));
                     self.calendar_state = None;
                 }

--- a/src/widgets/todos/input.rs
+++ b/src/widgets/todos/input.rs
@@ -2,14 +2,17 @@ use ratatui::{
     crossterm::event::{KeyCode, KeyEvent, KeyModifiers},
     prelude::{Buffer, Color, Constraint, Layout, Rect, Style, Stylize, Widget},
     text::Span,
-    widgets::{Block, Paragraph},
+    widgets::{Block, Clear, Paragraph},
 };
 use ratatui_textarea::TextArea;
 use time::OffsetDateTime;
 
 use crate::{kinds::repeat::Repeat, tabs::todos::COLOR, utils::date::now};
 
-use super::calendar::{CalendarAction, CalendarProps, CalendarState, CalendarWidget};
+use super::{
+    calendar::{CalendarAction, CalendarProps, CalendarState, CalendarWidget},
+    repeat::{RepeatAction, RepeatProps, RepeatState, RepeatWidget},
+};
 
 /// Action returned by the input widget after handling a key event.
 pub enum InputAction {
@@ -55,12 +58,14 @@ impl InputProps {
     }
 }
 
-/// Stateful container for the todo input, owns props and optional calendar overlay.
+/// Stateful container for the todo input, owns props and optional picker overlays.
 pub struct InputState {
     /// Mutable props updated as the user types or picks a date/repeat.
     props: InputProps,
     /// Active calendar state when the date-picker overlay is open.
     calendar_state: Option<CalendarState>,
+    /// Active repeat state when the repeat-picker overlay is open.
+    repeat_state: Option<RepeatState>,
 }
 
 impl InputState {
@@ -69,6 +74,7 @@ impl InputState {
         Self {
             props,
             calendar_state: None,
+            repeat_state: None,
         }
     }
 
@@ -77,17 +83,28 @@ impl InputState {
         &self.props
     }
 
-    /// Handles a key event, delegating to the calendar overlay when open.
+    /// Handles a key event, delegating to the calendar or repeat overlay when open.
     pub fn handle(&mut self, key: KeyEvent) -> InputAction {
         if let Some(cal) = &mut self.calendar_state {
             match cal.handle(key) {
-                CalendarAction::Confirm { date, repeat } => {
+                CalendarAction::Confirm { date } => {
                     self.props.date = date.map(|d| now().replace_date(d));
-                    self.props.repeat = repeat;
                     self.calendar_state = None;
                 }
                 CalendarAction::Cancel => self.calendar_state = None,
                 CalendarAction::None => {}
+            }
+            return InputAction::None;
+        }
+
+        if let Some(rep) = &mut self.repeat_state {
+            match rep.handle(key) {
+                RepeatAction::Confirm(repeat) => {
+                    self.props.repeat = repeat;
+                    self.repeat_state = None;
+                }
+                RepeatAction::Cancel => self.repeat_state = None,
+                RepeatAction::None => {}
             }
             return InputAction::None;
         }
@@ -107,8 +124,10 @@ impl InputState {
             KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 self.calendar_state = Some(CalendarState::new(CalendarProps::new(
                     self.props.date.map(|dt| dt.date()),
-                    self.props.repeat.as_ref(),
                 )));
+            }
+            KeyCode::Char('e') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.repeat_state = Some(RepeatState::new(RepeatProps::new(self.props.repeat.as_ref())));
             }
             _ => {
                 self.props.textarea.input(key);
@@ -122,6 +141,30 @@ impl InputState {
         if let Some(cal) = &self.calendar_state {
             CalendarWidget::new(cal.props()).render(area, buf);
         }
+    }
+
+    /// Renders the repeat-picker overlay into the buffer if it is currently open.
+    pub fn render_repeat(&self, area: Rect, buf: &mut Buffer) {
+        let Some(rep) = &self.repeat_state else { return };
+
+        let popup_w = 26u16;
+        let popup_h = 14u16;
+        let popup = ratatui::layout::Rect {
+            x: area.x + area.width.saturating_sub(popup_w) / 2,
+            y: area.y + area.height.saturating_sub(popup_h) / 2,
+            width: popup_w.min(area.width),
+            height: popup_h.min(area.height),
+        };
+
+        Clear.render(popup, buf);
+
+        let block = Block::bordered()
+            .title(" Repeat ")
+            .border_style(Style::default().fg(COLOR));
+        let inner = block.inner(popup);
+        block.render(popup, buf);
+
+        RepeatWidget::new(rep.props()).render(inner, buf);
     }
 }
 
@@ -139,36 +182,21 @@ impl<'a> InputWidget<'a> {
 }
 
 impl Widget for &InputWidget<'_> {
-    /// Renders the textarea alongside the due-date block into the buffer.
+    /// Renders the textarea alongside separate date and repeat blocks.
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let date_area_width = self
+        let repeat_width = self
             .props
             .repeat
             .as_ref()
             .map(|r| (r.label().len() as u16 + 4).max(14))
             .unwrap_or(14);
 
-        let icon_width = if self.props.repeat.is_some() { 2 } else { 0 };
-        let [icon_area, text_area, date_area] = Layout::horizontal([
-            Constraint::Length(icon_width),
+        let [text_area, date_area, repeat_area] = Layout::horizontal([
             Constraint::Fill(1),
-            Constraint::Length(date_area_width),
+            Constraint::Length(14),
+            Constraint::Length(repeat_width),
         ])
         .areas(area);
-
-        if self.props.repeat.is_some() {
-            let v_offset = icon_area.height / 2;
-            let centered = Rect {
-                y: icon_area.y + v_offset,
-                height: 1,
-                ..icon_area
-            };
-            Paragraph::new(Repeat::icon())
-                .fg(COLOR)
-                .bold()
-                .centered()
-                .render(centered, buf);
-        }
 
         Widget::render(&self.props.textarea, text_area, buf);
 
@@ -176,16 +204,24 @@ impl Widget for &InputWidget<'_> {
             Some(d) => format!("{}", d.date()),
             None => "no date".to_string(),
         };
-
-        let mut block = Block::bordered()
+        let date_block = Block::bordered()
             .title(Span::from(" ^d ").fg(Color::DarkGray).bold())
             .border_style(Style::default().fg(COLOR));
-        if let Some(repeat) = self.props.repeat.as_ref() {
-            block = block.title_bottom(Span::from(format!(" {} ", repeat.label())).fg(COLOR).bold());
-        }
-        let inner = block.inner(date_area);
-        block.render(date_area, buf);
+        let date_inner = date_block.inner(date_area);
+        date_block.render(date_area, buf);
+        Paragraph::new(date_str).fg(COLOR).centered().render(date_inner, buf);
 
-        Paragraph::new(date_str).fg(COLOR).centered().render(inner, buf);
+        let repeat_str = self
+            .props
+            .repeat
+            .as_ref()
+            .map(|r| r.label().to_string())
+            .unwrap_or_else(|| "no repeat".to_string());
+        let repeat_block = Block::bordered()
+            .title(Span::from(" ^e ").fg(Color::DarkGray).bold())
+            .border_style(Style::default().fg(COLOR));
+        let repeat_inner = repeat_block.inner(repeat_area);
+        repeat_block.render(repeat_area, buf);
+        Paragraph::new(repeat_str).fg(COLOR).centered().render(repeat_inner, buf);
     }
 }


### PR DESCRIPTION
## Summary

- Split date and repeat into independent pickers in the todo add/edit input: `^d` opens the date-only calendar, `^e` opens the repeat picker directly (previously repeat was nested inside the calendar via `[r]`)
- Input row now shows two separate bordered blocks: `[^d] date` and `[^e] repeat`
- Fixed `[x] No Date` in the calendar picker — it was a no-op before, now correctly clears the date
- Fixed repeat scheduling for overdue (Due page) todos: toggling a due repeating todo no longer schedules the next occurrence for today — it advances past today to the next valid future date